### PR TITLE
Update Timer_example2

### DIFF
--- a/code/Timer_example2/SimpleTimer.cpp
+++ b/code/Timer_example2/SimpleTimer.cpp
@@ -1,0 +1,241 @@
+/*
+ * SimpleTimer.cpp
+ *
+ * SimpleTimer - A timer library for Arduino.
+ * Author: mromani@ottotecnica.com
+ * Copyright (c) 2010 OTTOTECNICA Italy
+ *
+ * This library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser
+ * General Public License along with this library; if not,
+ * write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+
+#include "SimpleTimer.h"
+
+
+// Select time function:
+//static inline unsigned long elapsed() { return micros(); }
+static inline unsigned long elapsed() { return millis(); }
+
+
+SimpleTimer::SimpleTimer() {
+    unsigned long current_millis = elapsed();
+
+    for (int i = 0; i < MAX_TIMERS; i++) {
+        enabled[i] = false;
+        callbacks[i] = 0;                   // if the callback pointer is zero, the slot is free, i.e. doesn't "contain" any timer
+        prev_millis[i] = current_millis;
+        numRuns[i] = 0;
+    }
+
+    numTimers = 0;
+}
+
+
+void SimpleTimer::run() {
+    int i;
+    unsigned long current_millis;
+
+    // get current time
+    current_millis = elapsed();
+
+    for (i = 0; i < MAX_TIMERS; i++) {
+
+        toBeCalled[i] = DEFCALL_DONTRUN;
+
+        // no callback == no timer, i.e. jump over empty slots
+        if (callbacks[i]) {
+
+            // is it time to process this timer ?
+            // see http://arduino.cc/forum/index.php/topic,124048.msg932592.html#msg932592
+
+            if (current_millis - prev_millis[i] >= delays[i]) {
+
+                // update time
+                //prev_millis[i] = current_millis;
+                prev_millis[i] += delays[i];
+
+                // check if the timer callback has to be executed
+                if (enabled[i]) {
+
+                    // "run forever" timers must always be executed
+                    if (maxNumRuns[i] == RUN_FOREVER) {
+                        toBeCalled[i] = DEFCALL_RUNONLY;
+                    }
+                    // other timers get executed the specified number of times
+                    else if (numRuns[i] < maxNumRuns[i]) {
+                        toBeCalled[i] = DEFCALL_RUNONLY;
+                        numRuns[i]++;
+
+                        // after the last run, delete the timer
+                        if (numRuns[i] >= maxNumRuns[i]) {
+                            toBeCalled[i] = DEFCALL_RUNANDDEL;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (i = 0; i < MAX_TIMERS; i++) {
+        switch(toBeCalled[i]) {
+            case DEFCALL_DONTRUN:
+                break;
+
+            case DEFCALL_RUNONLY:
+                (*callbacks[i])();
+                break;
+
+            case DEFCALL_RUNANDDEL:
+                (*callbacks[i])();
+                deleteTimer(i);
+                break;
+        }
+    }
+}
+
+
+// find the first available slot
+// return -1 if none found
+int SimpleTimer::findFirstFreeSlot() {
+    int i;
+
+    // all slots are used
+    if (numTimers >= MAX_TIMERS) {
+        return -1;
+    }
+
+    // return the first slot with no callback (i.e. free)
+    for (i = 0; i < MAX_TIMERS; i++) {
+        if (callbacks[i] == 0) {
+            return i;
+        }
+    }
+
+    // no free slots found
+    return -1;
+}
+
+
+int SimpleTimer::setTimer(long d, timer_callback f, int n) {
+    int freeTimer;
+
+    freeTimer = findFirstFreeSlot();
+    if (freeTimer < 0) {
+        return -1;
+    }
+
+    if (f == NULL) {
+        return -1;
+    }
+
+    delays[freeTimer] = d;
+    callbacks[freeTimer] = f;
+    maxNumRuns[freeTimer] = n;
+    enabled[freeTimer] = true;
+    prev_millis[freeTimer] = elapsed();
+
+    numTimers++;
+
+    return freeTimer;
+}
+
+
+int SimpleTimer::setInterval(long d, timer_callback f) {
+    return setTimer(d, f, RUN_FOREVER);
+}
+
+
+int SimpleTimer::setTimeout(long d, timer_callback f) {
+    return setTimer(d, f, RUN_ONCE);
+}
+
+
+void SimpleTimer::deleteTimer(int timerId) {
+    if (timerId >= MAX_TIMERS) {
+        return;
+    }
+
+    // nothing to delete if no timers are in use
+    if (numTimers == 0) {
+        return;
+    }
+
+    // don't decrease the number of timers if the
+    // specified slot is already empty
+    if (callbacks[timerId] != NULL) {
+        callbacks[timerId] = 0;
+        enabled[timerId] = false;
+        toBeCalled[timerId] = DEFCALL_DONTRUN;
+        delays[timerId] = 0;
+        numRuns[timerId] = 0;
+
+        // update number of timers
+        numTimers--;
+    }
+}
+
+
+// function contributed by code@rowansimms.com
+void SimpleTimer::restartTimer(int numTimer) {
+    if (numTimer >= MAX_TIMERS) {
+        return;
+    }
+
+    prev_millis[numTimer] = elapsed();
+}
+
+
+boolean SimpleTimer::isEnabled(int numTimer) {
+    if (numTimer >= MAX_TIMERS) {
+        return false;
+    }
+
+    return enabled[numTimer];
+}
+
+
+void SimpleTimer::enable(int numTimer) {
+    if (numTimer >= MAX_TIMERS) {
+        return;
+    }
+
+    enabled[numTimer] = true;
+}
+
+
+void SimpleTimer::disable(int numTimer) {
+    if (numTimer >= MAX_TIMERS) {
+        return;
+    }
+
+    enabled[numTimer] = false;
+}
+
+
+void SimpleTimer::toggle(int numTimer) {
+    if (numTimer >= MAX_TIMERS) {
+        return;
+    }
+
+    enabled[numTimer] = !enabled[numTimer];
+}
+
+
+int SimpleTimer::getNumTimers() {
+    return numTimers;
+}

--- a/code/Timer_example2/SimpleTimer.h
+++ b/code/Timer_example2/SimpleTimer.h
@@ -1,0 +1,124 @@
+/*
+ * SimpleTimer.h
+ *
+ * SimpleTimer - A timer library for Arduino.
+ * Author: mromani@ottotecnica.com
+ * Copyright (c) 2010 OTTOTECNICA Italy
+ *
+ * This library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software
+ * Foundation; either version 2.1 of the License, or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will
+ * be useful, but WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser
+ * General Public License along with this library; if not,
+ * write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ */
+
+
+#ifndef SIMPLETIMER_H
+#define SIMPLETIMER_H
+
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <Arduino.h>
+#else
+#include <WProgram.h>
+#endif
+
+typedef void (*timer_callback)(void);
+
+class SimpleTimer {
+
+public:
+    // maximum number of timers
+    const static int MAX_TIMERS = 10;
+
+    // setTimer() constants
+    const static int RUN_FOREVER = 0;
+    const static int RUN_ONCE = 1;
+
+    // constructor
+    SimpleTimer();
+
+    // this function must be called inside loop()
+    void run();
+
+    // call function f every d milliseconds
+    int setInterval(long d, timer_callback f);
+
+    // call function f once after d milliseconds
+    int setTimeout(long d, timer_callback f);
+
+    // call function f every d milliseconds for n times
+    int setTimer(long d, timer_callback f, int n);
+
+    // destroy the specified timer
+    void deleteTimer(int numTimer);
+
+    // restart the specified timer
+    void restartTimer(int numTimer);
+
+    // returns true if the specified timer is enabled
+    boolean isEnabled(int numTimer);
+
+    // enables the specified timer
+    void enable(int numTimer);
+
+    // disables the specified timer
+    void disable(int numTimer);
+
+    // enables the specified timer if it's currently disabled,
+    // and vice-versa
+    void toggle(int numTimer);
+
+    // returns the number of used timers
+    int getNumTimers();
+
+    // returns the number of available timers
+    int getNumAvailableTimers() { return MAX_TIMERS - numTimers; };
+
+private:
+    // deferred call constants
+    const static int DEFCALL_DONTRUN = 0;       // don't call the callback function
+    const static int DEFCALL_RUNONLY = 1;       // call the callback function but don't delete the timer
+    const static int DEFCALL_RUNANDDEL = 2;      // call the callback function and delete the timer
+
+    // find the first available slot
+    int findFirstFreeSlot();
+
+    // value returned by the millis() function
+    // in the previous run() call
+    unsigned long prev_millis[MAX_TIMERS];
+
+    // pointers to the callback functions
+    timer_callback callbacks[MAX_TIMERS];
+
+    // delay values
+    long delays[MAX_TIMERS];
+
+    // number of runs to be executed for each timer
+    int maxNumRuns[MAX_TIMERS];
+
+    // number of executed runs for each timer
+    int numRuns[MAX_TIMERS];
+
+    // which timers are enabled
+    boolean enabled[MAX_TIMERS];
+
+    // deferred function call (sort of) - N.B.: this array is only used in run()
+    int toBeCalled[MAX_TIMERS];
+
+    // actual number of timers in use
+    int numTimers;
+};
+
+#endif

--- a/code/Timer_example2/Timer_example2.ino
+++ b/code/Timer_example2/Timer_example2.ino
@@ -1,102 +1,122 @@
 #include "SimpleTimer.h"
 
-                                        //TEST COMMENT 
-                                        //TEST COMMENT 2
-int counter; 
-boolean forthefirsttime = true;
-boolean locked = false;
-SimpleTimer timer;
-int mysimpletimerid;
-int numberoforders;
-int myordertimerid;
-int newordertimerid;
+                                        
+int counter;                                        //it counts the failed connections to the uC
+boolean DoDisable_mysimpletimer = true;             //boolean variable - if it is true, the Mysimpletimer will be disabled for the actual running cycle
+boolean DoDisable_neworderstimer = true;            //boolean variable - if it is true, the Neworderstimer will be disabled for the actual running cycle                  
+SimpleTimer timer;                                  
+int numberoforders;                                 //# of incoming orders
+int mysimpletimerid;                                //timer ID                              
+int myordertimerid;                                 //timer ID
+int neworderstimerid;                               //timer ID
+
 void setup()
 {
- counter = 1;                  //counting failed connections
+ counter = 1;                                       //counting failed connections
  Serial.begin(9600);
  
  //TIMER BLOCK 0
- mysimpletimerid= timer.setTimeout (8000,RetryTimeout);
- myordertimerid = timer.setInterval (15000,FactoryTerminatedOrder); 
+ mysimpletimerid= timer.setInterval (8000,RetryTimeout);                //8 seconds timeout for ARDUINO_ACK_RETRY_TIMEOUT 
+ myordertimerid = timer.setInterval (15000,FactoryTerminatedOrder);     //15 seconds for each order to be completed by the factory (in reality 3 minutes) 
+ neworderstimerid = timer.setInterval (5000, NewOrderReceived);         //after the factory executed all orders, 5 seconds later new orders "are received"
  //END OF TIMER BLOCK 0
  
- numberoforders = random(5);
+ numberoforders = 2;                                                    //suppose that there are already some orders registered (starting state)
 }
 
  
 void loop()
 {  
-   timer.run();
-   if (forthefirsttime == true)
-   {
+  //TIMER BLOCK 1 
+   timer.run();                                                       //start all timers
+   if (DoDisable_mysimpletimer == true)                               //stop the mysimpletimer immediately; no need for it right now; it will be started only if there are
+   {                                                                  //at least 10 failed connection trials (final number of allowed failed connections not decided yet)
     timer.disable(mysimpletimerid);
    }
-   
+   if (DoDisable_neworderstimer ==true)                               //stop the neworderstimer immediately; no need for it right now; it will be started only if the
+   {                                                                  //factory is ready with all the orders
+    timer.disable(neworderstimerid);
+   }
+  //END OF TIMER BLOCK 1
+  
    //YOUR PROGRAMM HERE:
-    delay(1000);
+    delay(1000);                                                     //count up in a one-second-tick
     Serial.print("Actual time is ");
     Serial.print(millis());
     Serial.print("[msec] (#failed connections= ");
     Serial.print(counter);
     Serial.println(").");
-    counter=counter+1;
+    counter=counter+1;                                              //count up (as if it would be registered a failed connection every second)
 
     
-    if ((counter>10)&&(forthefirsttime==true))                      
+    if ((counter>10)&&(DoDisable_mysimpletimer==true))              //if threshold is reached for the first time                         
     {
       Serial.print("Too many failed connections. Channel will now be locked for 8 seconds (timestamp (msec): ");
       Serial.print (millis());
-      Serial.println(")");
-      locked = true;                           //global boolean variable, that will be used in the other functions to manage channel's status
-      forthefirsttime = false; 
-      mysimpletimerid= timer.setTimeout (8000,RetryTimeout); 
-      timer.enable(mysimpletimerid);
-      timer.restartTimer(mysimpletimerid);       
-          }//end if
+      Serial.println(")");                         
+
+     //TIMER BLOCK 2
+      timer.enable(mysimpletimerid);                              //enable the formerly disabled timer    
+      timer.restartTimer(mysimpletimerid);                        //restart timer (reference time is NOW)    
+      DoDisable_mysimpletimer = false;                            //don't let the program disable the timer in the next running cycle (with the if statement at the code's beginning)
+     //END OF TIMER BLOCK 2
      
-     if (numberoforders==0)
+     }//end if
+     
+     if (numberoforders==0)                                       //if no more orders left in the factory queue
      {
-      numberoforders = -1; //to avoid entering this loop in the next cycle
-      timer.disable(myordertimerid);      
-      newordertimerid = timer.setTimeout (5000, NewOrderReceived);
-      timer.enable(newordertimerid);
-      timer.restartTimer(newordertimerid);
-      
+      numberoforders = -1;                                        //avoid entering this loop in the next cycle
+
+      //TIMER BLOCK 2
+      timer.disable(myordertimerid);                              //stop the interval timer       
+      timer.enable(neworderstimerid);                             //enable the neworderstimer
+      timer.restartTimer(neworderstimerid);                       //restart the neworderstimer (reference time is NOW); this timer will "generate" in 5 seconds some new orders
+      DoDisable_neworderstimer = false;                           //don't let the program disable the timer in the next running cycle (with the if statement at the code's beginning)
+      //END OF TIMER BLOCK 2
      }
 
 }
 
-//TIMER BLOCK 3
+//TIMER BLOCK 3 - interrupt routines
 void RetryTimeout()
 {
-  locked = false;                             //global boolean variable, that will be used in the other functions to manage channel's status
   Serial.print("Channel is open again (timestamp (msec): ");
   Serial.print (millis());
   Serial.println(")"); 
-  forthefirsttime  = true; 
-  counter = 1;                
+  counter = 1;                                                   //failed connections counter is reset 
+  DoDisable_mysimpletimer  = true;                               //let the program disable the timer in the next running cycle (otherwise it would trigger again automatically in 8 seconds) 
+                
 }
-void FactoryTerminatedOrder()
+
+void FactoryTerminatedOrder()                                   //factory executed one order
 {
-  numberoforders = numberoforders -1;
+  numberoforders = numberoforders -1;                           //decrement number of orders
   if (numberoforders ==0)
   {
-    Serial.println("All orders terminated");
+    Serial.print("All orders terminated (time: ");
+    Serial.print(millis());
+    Serial.println(")");
   }
   else
   {
-     Serial.print("Factory ready mit one order. Remaining orders= ");
+     Serial.print("Factory ready with one order. Remaining orders= ");
      Serial.println(numberoforders);
   }
 }
- void NewOrderReceived()
+ void NewOrderReceived()                              //interrupt routine : new orders will be "generated" (as if the uC would receive a/some new order(s) )  
  {
-  numberoforders = random(5);
+  numberoforders = 2;                                 //new orders "received"
   Serial.print(numberoforders);
-  Serial.println (" new orders received");
-  timer.enable(myordertimerid);
-  timer.restartTimer(myordertimerid);
+  Serial.print (" new orders received (time: ");
+  Serial.print(millis());
+  Serial.println(")");
+  
+  timer.enable(myordertimerid);                               //enable the myordertimer 
+  timer.restartTimer(myordertimerid);                         //restart it  (reference time is NOW)
+   
+  DoDisable_neworderstimer = true;                            //let the program disable the timer in the next running cycle (otherwise it would trigger again automatically in 5 seconds) 
  }
+ //END OF TIMER BLOCK 3
 
 //END OF TIMER BLOCK 3
  


### PR DESCRIPTION
The "Timeout" timers have been deleted and they were replaced by
"Interval" timers. They seem to be easier to control than  the "Timeout"
timers. Now all three timers are working well, they are simulating the
reception of new orders coming from the App. A simple counter simulates
failed connection to the uC, after 10 failed connections the
RETRY_TIMEOUT is activated (for 8 seconds). The factory executes one
order in 15 seconds. I've copied the header files into the folder.
Application should now be able to run directly from GitHub Desktop.