### PR TITLE
Fix serial bug in spike SW_UART_MARIO

### DIFF
--- a/code/Spikes/SW_UART_MARIO/SW_UART_MARIO.ino
+++ b/code/Spikes/SW_UART_MARIO/SW_UART_MARIO.ino
@@ -33,7 +33,7 @@ void loop()
   // read from SW Serial and write to HW Serial
   if (mySerial.available()) 
   {
-    Serial.write(Serial.read()); // sends to serial monitor
+    Serial.write(mySerial.read()); // sends to serial monitor
   }
 
   // read from HW serial and write to SW serial


### PR DESCRIPTION
Bug wrote Hw serial input buffer to Hw serial output buffer. This wasn't supposed to happen. Sw serial input buffer needs to  be written to Hw serial output buffer to have a bidrectional communication. Discovered in Slack https://arduinoteampmesws2016.slack.com/archives/general/p1486499858000004.